### PR TITLE
feat: 과목 엑셀파일 업로드 기능 구현 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,8 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.apache.poi:poi:5.3.0'
+    implementation 'org.apache.poi:poi-ooxml:5.3.0'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/kr/allcll/seatfinder/excel/ExcelSubject.java
+++ b/src/main/java/kr/allcll/seatfinder/excel/ExcelSubject.java
@@ -1,0 +1,32 @@
+package kr.allcll.seatfinder.excel;
+
+import lombok.Builder;
+
+@Builder
+public record ExcelSubject(
+    String offeringUniversity,
+    String offeringDepartment,
+    String subjectNumber,
+    String classDivision,
+    String subjectName,
+    String subjectType,
+    String electiveArea,
+    String academicYearSemester,
+    String credit,
+    String theoryHours,
+    String practiceHours,
+    String classType,
+    String exchangeEligible,
+    String schedule,
+    String lectureRoom,
+    String mainProfessor,
+    String supervisingDepartment,
+    String notesAndRestrictions,
+    String classCategory,
+    String onlineLecture,
+    String lectureLanguage,
+    String foreignerOnly,
+    String domesticOnly
+) {
+
+}

--- a/src/main/java/kr/allcll/seatfinder/excel/SubjectSheetHeader.java
+++ b/src/main/java/kr/allcll/seatfinder/excel/SubjectSheetHeader.java
@@ -1,0 +1,52 @@
+package kr.allcll.seatfinder.excel;
+
+import java.util.Arrays;
+import java.util.function.BiConsumer;
+import kr.allcll.seatfinder.excel.ExcelSubject.ExcelSubjectBuilder;
+
+public enum SubjectSheetHeader {
+
+    OFFERING_UNIVERSITY("개설대학", ExcelSubjectBuilder::offeringUniversity),
+    OFFERING_DEPARTMENT("개설학과전공", ExcelSubjectBuilder::offeringDepartment),
+    SUBJECT_NUMBER("학수번호", ExcelSubjectBuilder::subjectNumber),
+    CLASS_DIVISION("분반", ExcelSubjectBuilder::classDivision),
+    SUBJECT_NAME("교과목명", ExcelSubjectBuilder::subjectName),
+    SUBJECT_TYPE("이수구분", ExcelSubjectBuilder::subjectType),
+    ELECTIVE_AREA("선택영역", ExcelSubjectBuilder::electiveArea),
+    ACADEMIC_YEAR_SEMESTER("학년\n(학기)", ExcelSubjectBuilder::academicYearSemester),
+    CREDIT("학점", ExcelSubjectBuilder::credit),
+    THEORY_HOURS("이론", ExcelSubjectBuilder::theoryHours),
+    PRACTICE_HOURS("실습", ExcelSubjectBuilder::practiceHours),
+    CLASS_TYPE("수업\n유형", ExcelSubjectBuilder::classType),
+    EXCHANGE_ELIGIBLE("학점교류\n수강가능", ExcelSubjectBuilder::exchangeEligible),
+    SCHEDULE("요일 및 강의시간", ExcelSubjectBuilder::schedule),
+    LECTURE_ROOM("강의실", ExcelSubjectBuilder::lectureRoom),
+    MAIN_PROFESSOR("메인\n교수명", ExcelSubjectBuilder::mainProfessor),
+    SUPERVISING_DEPARTMENT("주관학과", ExcelSubjectBuilder::supervisingDepartment),
+    NOTES_AND_RESTRICTIONS("수강대상및유의사항", ExcelSubjectBuilder::notesAndRestrictions),
+    CLASS_CATEGORY("강좌유형", ExcelSubjectBuilder::classCategory),
+    ONLINE_LECTURE("사이버강좌", ExcelSubjectBuilder::onlineLecture),
+    LECTURE_LANGUAGE("강의언어", ExcelSubjectBuilder::lectureLanguage),
+    FOREIGNER_ONLY("외국인\n전용", ExcelSubjectBuilder::foreignerOnly),
+    DOMESTIC_ONLY("내국인\n전용", ExcelSubjectBuilder::domesticOnly),
+    ;
+
+    private final String headerName;
+    private final BiConsumer<ExcelSubjectBuilder, String> setter;
+
+    SubjectSheetHeader(String headerName, BiConsumer<ExcelSubjectBuilder, String> setter) {
+        this.headerName = headerName;
+        this.setter = setter;
+    }
+
+    public static SubjectSheetHeader from(String headerName) {
+        return Arrays.stream(values())
+            .filter(header -> header.headerName.equals(headerName))
+            .findFirst()
+            .orElseThrow(() -> new IllegalArgumentException("정의되지 않은 엑셀 컬럼: " + headerName));
+    }
+
+    public void setField(ExcelSubjectBuilder builder, String value) {
+        this.setter.accept(builder, value);
+    }
+}

--- a/src/main/java/kr/allcll/seatfinder/excel/SubjectSheetHeaderMapper.java
+++ b/src/main/java/kr/allcll/seatfinder/excel/SubjectSheetHeaderMapper.java
@@ -1,0 +1,44 @@
+package kr.allcll.seatfinder.excel;
+
+import java.util.HashMap;
+import java.util.Map;
+import kr.allcll.seatfinder.excel.ExcelSubject.ExcelSubjectBuilder;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.Row;
+
+@Slf4j
+public class SubjectSheetHeaderMapper {
+
+    private final Map<Integer, SubjectSheetHeader> headerMap;
+
+    public SubjectSheetHeaderMapper(Row headerRow) {
+        this.headerMap = parseExcelHeaders(headerRow);
+    }
+
+    private Map<Integer, SubjectSheetHeader> parseExcelHeaders(Row headerRow) {
+        Map<Integer, SubjectSheetHeader> headers = new HashMap<>();
+        for (Cell cell : headerRow) {
+            String headerName = cell.getStringCellValue();
+            try {
+                SubjectSheetHeader header = SubjectSheetHeader.from(headerName);
+                headers.put(cell.getColumnIndex(), header);
+            } catch (IllegalArgumentException e) {
+                log.warn("정의되지 않은 과목 엑셀 헤더: {}", e.getMessage());
+            }
+        }
+        return headers;
+    }
+
+    public ExcelSubject mapRowToSubject(Row row) {
+        ExcelSubjectBuilder subjectBuilder = ExcelSubject.builder();
+        for (Map.Entry<Integer, SubjectSheetHeader> entry : headerMap.entrySet()) {
+            int columnIndex = entry.getKey();
+            SubjectSheetHeader subjectHeader = entry.getValue();
+            Cell cell = row.getCell(columnIndex);
+            String cellValue = (cell == null) ? null : cell.getStringCellValue();
+            subjectHeader.setField(subjectBuilder, cellValue);
+        }
+        return subjectBuilder.build();
+    }
+}

--- a/src/main/java/kr/allcll/seatfinder/excel/SubjectSheetParser.java
+++ b/src/main/java/kr/allcll/seatfinder/excel/SubjectSheetParser.java
@@ -1,0 +1,51 @@
+package kr.allcll.seatfinder.excel;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.IntStream;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.io.FilenameUtils;
+import org.apache.poi.hssf.usermodel.HSSFWorkbook;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+@Slf4j
+@Component
+public class SubjectSheetParser {
+
+    private static final int TARGET_SHEET_INDEX = 0;
+    private static final int HEADER_ROW_INDEX = 0;
+    private static final String FILE_FORMAT_XLSX = "xlsx";
+    private static final String FILE_FORMAT_XLS = "xls";
+
+    public SubjectsParsingResponse parse(MultipartFile file) throws IOException {
+        Workbook workbook = getWorkbook(file);
+        Sheet sheet = workbook.getSheetAt(TARGET_SHEET_INDEX);
+        Row headerRow = sheet.getRow(HEADER_ROW_INDEX);
+        SubjectSheetHeaderMapper headerMapper = new SubjectSheetHeaderMapper(headerRow);
+        return parseRows(sheet, headerMapper);
+    }
+
+    private Workbook getWorkbook(MultipartFile file) throws IOException {
+        String extension = FilenameUtils.getExtension(file.getOriginalFilename());
+        if (FILE_FORMAT_XLSX.equals(extension)) {
+            return new XSSFWorkbook(file.getInputStream());
+        } else if (FILE_FORMAT_XLS.equals(extension)) {
+            return new HSSFWorkbook(file.getInputStream());
+        }
+        throw new IOException("지원하지 않는 파일 형식입니다. 입력한 파일 형식: " + extension);
+    }
+
+    private SubjectsParsingResponse parseRows(Sheet worksheet, SubjectSheetHeaderMapper headerMapper) {
+        log.info("입력된 엑셀 데이터 행 길이 (헤더 포함): {}", worksheet.getPhysicalNumberOfRows());
+        List<ExcelSubject> excelSubjects = IntStream.range(1, worksheet.getPhysicalNumberOfRows())
+            .mapToObj(worksheet::getRow)
+            .map(headerMapper::mapRowToSubject)
+            .toList();
+        return new SubjectsParsingResponse(excelSubjects);
+    }
+}

--- a/src/main/java/kr/allcll/seatfinder/excel/SubjectsParsingResponse.java
+++ b/src/main/java/kr/allcll/seatfinder/excel/SubjectsParsingResponse.java
@@ -2,6 +2,8 @@ package kr.allcll.seatfinder.excel;
 
 import java.util.List;
 
-public record SubjectsParsingResponse(List<ExcelSubject> excelSubjects) {
+public record SubjectsParsingResponse(
+    List<ExcelSubject> excelSubjects
+) {
 
 }

--- a/src/main/java/kr/allcll/seatfinder/excel/SubjectsParsingResponse.java
+++ b/src/main/java/kr/allcll/seatfinder/excel/SubjectsParsingResponse.java
@@ -1,0 +1,7 @@
+package kr.allcll.seatfinder.excel;
+
+import java.util.List;
+
+public record SubjectsParsingResponse(List<ExcelSubject> excelSubjects) {
+
+}

--- a/src/main/java/kr/allcll/seatfinder/subject/Subject.java
+++ b/src/main/java/kr/allcll/seatfinder/subject/Subject.java
@@ -1,0 +1,43 @@
+package kr.allcll.seatfinder.subject;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PUBLIC)
+public class Subject {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String offeringUniversity;      // 개설대학
+    private String offeringDepartment;      // 개설학과전공
+    private String subjectNumber;           // 학수번호
+    private String classDivision;           // 분반
+    private String subjectName;             // 교과목명
+    private String subjectType;             // 이수구분
+    private String electiveArea;            // 선택영역
+    private String academicYearSemester;    // 학년 (학기)
+    private String credit;                  // 학점
+    private String theoryHours;             // 이론
+    private String practiceHours;           // 실습
+    private String classType;               // 수업 유형
+    private String exchangeEligible;        // 학점교류 수강가능
+    private String schedule;                // 요일 및 강의시간
+    private String lectureRoom;             // 강의실
+    private String mainProfessor;           // 메인 교수명
+    private String supervisingDepartment;   // 주관학과
+    private String notesAndRestrictions;    // 수강대상및유의사항
+    private String classCategory;           // 강좌유형
+    private String onlineLecture;           // 사이버강좌
+    private String lectureLanguage;         // 강의언어
+    private String foreignerOnly;           // 외국인 전용
+    private String domesticOnly;            // 내국인 전용
+}

--- a/src/main/java/kr/allcll/seatfinder/subject/SubjectApi.java
+++ b/src/main/java/kr/allcll/seatfinder/subject/SubjectApi.java
@@ -20,7 +20,7 @@ public class SubjectApi {
     @PostMapping("/api/subject/upload")
     public ResponseEntity<String> uploadSubjects(@RequestParam MultipartFile file) throws IOException {
         SubjectsParsingResponse parsedSubjects = subjectSheetParser.parse(file);
-        SubjectsRequest subjectsRequest = SubjectsRequest.toSubjectsRequest(parsedSubjects);
+        SubjectsRequest subjectsRequest = SubjectsRequest.from(parsedSubjects);
         subjectApp.save(subjectsRequest);
         return ResponseEntity.ok("업로드에 성공했습니다.");
     }

--- a/src/main/java/kr/allcll/seatfinder/subject/SubjectApi.java
+++ b/src/main/java/kr/allcll/seatfinder/subject/SubjectApi.java
@@ -14,14 +14,14 @@ import org.springframework.web.multipart.MultipartFile;
 @RequiredArgsConstructor
 public class SubjectApi {
 
-    private final SubjectApp subjectApp;
+    private final SubjectService subjectService;
     private final SubjectSheetParser subjectSheetParser;
 
     @PostMapping("/api/subject/upload")
     public ResponseEntity<String> uploadSubjects(@RequestParam MultipartFile file) throws IOException {
         SubjectsParsingResponse parsedSubjects = subjectSheetParser.parse(file);
         SubjectsRequest subjectsRequest = SubjectsRequest.from(parsedSubjects);
-        subjectApp.save(subjectsRequest);
+        subjectService.save(subjectsRequest);
         return ResponseEntity.ok("업로드에 성공했습니다.");
     }
 }

--- a/src/main/java/kr/allcll/seatfinder/subject/SubjectApi.java
+++ b/src/main/java/kr/allcll/seatfinder/subject/SubjectApi.java
@@ -1,0 +1,27 @@
+package kr.allcll.seatfinder.subject;
+
+import java.io.IOException;
+import kr.allcll.seatfinder.excel.SubjectSheetParser;
+import kr.allcll.seatfinder.excel.SubjectsParsingResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequiredArgsConstructor
+public class SubjectApi {
+
+    private final SubjectApp subjectApp;
+    private final SubjectSheetParser subjectSheetParser;
+
+    @PostMapping("/api/subject/upload")
+    public ResponseEntity<String> uploadSubjects(@RequestParam MultipartFile file) throws IOException {
+        SubjectsParsingResponse parsedSubjects = subjectSheetParser.parse(file);
+        SubjectsRequest subjectsRequest = SubjectsRequest.toSubjectsRequest(parsedSubjects);
+        subjectApp.save(subjectsRequest);
+        return ResponseEntity.ok("업로드에 성공했습니다.");
+    }
+}

--- a/src/main/java/kr/allcll/seatfinder/subject/SubjectApp.java
+++ b/src/main/java/kr/allcll/seatfinder/subject/SubjectApp.java
@@ -1,0 +1,17 @@
+package kr.allcll.seatfinder.subject;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class SubjectApp {
+
+    private final SubjectRepository subjectRepository;
+
+    public void save(SubjectsRequest subjectRequests) {
+        List<Subject> subjects = subjectRequests.toEntity();
+        subjectRepository.saveAll(subjects);
+    }
+}

--- a/src/main/java/kr/allcll/seatfinder/subject/SubjectRepository.java
+++ b/src/main/java/kr/allcll/seatfinder/subject/SubjectRepository.java
@@ -1,0 +1,7 @@
+package kr.allcll.seatfinder.subject;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SubjectRepository extends JpaRepository<Subject, Long> {
+
+}

--- a/src/main/java/kr/allcll/seatfinder/subject/SubjectRequest.java
+++ b/src/main/java/kr/allcll/seatfinder/subject/SubjectRequest.java
@@ -1,0 +1,87 @@
+package kr.allcll.seatfinder.subject;
+
+import kr.allcll.seatfinder.excel.ExcelSubject;
+
+public record SubjectRequest(
+    String offeringUniversity,
+    String offeringDepartment,
+    String subjectNumber,
+    String classDivision,
+    String subjectName,
+    String subjectType,
+    String electiveArea,
+    String academicYearSemester,
+    String credit,
+    String theoryHours,
+    String practiceHours,
+    String classType,
+    String exchangeEligible,
+    String schedule,
+    String lectureRoom,
+    String mainProfessor,
+    String supervisingDepartment,
+    String notesAndRestrictions,
+    String classCategory,
+    String onlineLecture,
+    String lectureLanguage,
+    String foreignerOnly,
+    String domesticOnly
+) {
+
+    public static SubjectRequest from(ExcelSubject subject) {
+        return new SubjectRequest(
+            subject.offeringUniversity(),
+            subject.offeringDepartment(),
+            subject.subjectNumber(),
+            subject.classDivision(),
+            subject.subjectName(),
+            subject.subjectType(),
+            subject.electiveArea(),
+            subject.academicYearSemester(),
+            subject.credit(),
+            subject.theoryHours(),
+            subject.practiceHours(),
+            subject.classType(),
+            subject.exchangeEligible(),
+            subject.schedule(),
+            subject.lectureRoom(),
+            subject.mainProfessor(),
+            subject.supervisingDepartment(),
+            subject.notesAndRestrictions(),
+            subject.classCategory(),
+            subject.onlineLecture(),
+            subject.lectureLanguage(),
+            subject.foreignerOnly(),
+            subject.domesticOnly()
+        );
+    }
+
+    public Subject toEntity() {
+        return new Subject(
+            null,
+            offeringUniversity,
+            offeringDepartment,
+            subjectNumber,
+            classDivision,
+            subjectName,
+            subjectType,
+            electiveArea,
+            academicYearSemester,
+            credit,
+            theoryHours,
+            practiceHours,
+            classType,
+            exchangeEligible,
+            schedule,
+            lectureRoom,
+            mainProfessor,
+            supervisingDepartment,
+            notesAndRestrictions,
+            classCategory,
+            onlineLecture,
+            lectureLanguage,
+            foreignerOnly,
+            domesticOnly
+        );
+    }
+}

--- a/src/main/java/kr/allcll/seatfinder/subject/SubjectService.java
+++ b/src/main/java/kr/allcll/seatfinder/subject/SubjectService.java
@@ -6,7 +6,7 @@ import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
-public class SubjectApp {
+public class SubjectService {
 
     private final SubjectRepository subjectRepository;
 

--- a/src/main/java/kr/allcll/seatfinder/subject/SubjectsRequest.java
+++ b/src/main/java/kr/allcll/seatfinder/subject/SubjectsRequest.java
@@ -1,0 +1,21 @@
+package kr.allcll.seatfinder.subject;
+
+import java.util.List;
+import kr.allcll.seatfinder.excel.ExcelSubject;
+import kr.allcll.seatfinder.excel.SubjectsParsingResponse;
+
+public record SubjectsRequest(List<SubjectRequest> subjectRequests) {
+
+    public static SubjectsRequest toSubjectsRequest(SubjectsParsingResponse subjectsParsingResponse) {
+        List<ExcelSubject> subjectsRequest = subjectsParsingResponse.excelSubjects();
+        return new SubjectsRequest(subjectsRequest.stream()
+            .map(SubjectRequest::from)
+            .toList());
+    }
+
+    public List<Subject> toEntity() {
+        return subjectRequests.stream()
+            .map(SubjectRequest::toEntity)
+            .toList();
+    }
+}

--- a/src/main/java/kr/allcll/seatfinder/subject/SubjectsRequest.java
+++ b/src/main/java/kr/allcll/seatfinder/subject/SubjectsRequest.java
@@ -4,7 +4,9 @@ import java.util.List;
 import kr.allcll.seatfinder.excel.ExcelSubject;
 import kr.allcll.seatfinder.excel.SubjectsParsingResponse;
 
-public record SubjectsRequest(List<SubjectRequest> subjectRequests) {
+public record SubjectsRequest(
+    List<SubjectRequest> subjectRequests
+) {
 
     public static SubjectsRequest from(SubjectsParsingResponse subjectsParsingResponse) {
         List<ExcelSubject> subjectsRequest = subjectsParsingResponse.excelSubjects();

--- a/src/main/java/kr/allcll/seatfinder/subject/SubjectsRequest.java
+++ b/src/main/java/kr/allcll/seatfinder/subject/SubjectsRequest.java
@@ -6,7 +6,7 @@ import kr.allcll.seatfinder.excel.SubjectsParsingResponse;
 
 public record SubjectsRequest(List<SubjectRequest> subjectRequests) {
 
-    public static SubjectsRequest toSubjectsRequest(SubjectsParsingResponse subjectsParsingResponse) {
+    public static SubjectsRequest from(SubjectsParsingResponse subjectsParsingResponse) {
         List<ExcelSubject> subjectsRequest = subjectsParsingResponse.excelSubjects();
         return new SubjectsRequest(subjectsRequest.stream()
             .map(SubjectRequest::from)

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=seat-finder

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,20 @@
+spring:
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: 'jdbc:h2:mem:test'
+    username: sa
+
+  h2:
+    console:
+      enabled: true
+      path: /h2-console
+
+  jpa:
+    database-platform: org.hibernate.dialect.H2Dialect
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.H2Dialect
+#        format_sql: true
+#        show_sql: true

--- a/src/test/java/kr/allcll/seatfinder/excel/SubjectSheetHeaderMapperTest.java
+++ b/src/test/java/kr/allcll/seatfinder/excel/SubjectSheetHeaderMapperTest.java
@@ -1,0 +1,50 @@
+package kr.allcll.seatfinder.excel;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import kr.allcll.seatfinder.support.fixture.SubjectExcelFileFixture;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.xssf.usermodel.XSSFSheet;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class SubjectSheetHeaderMapperTest {
+
+    @DisplayName("엑셀의 행을 과목 데이터로 변환한다.")
+    @Test
+    void mapRowToSubjectTest() {
+        XSSFWorkbook workbook = new XSSFWorkbook();
+        XSSFSheet sheet = workbook.createSheet("개설강좌");
+        Row headerRow = SubjectExcelFileFixture.createHeaderRow(sheet);
+        Row dataRow = SubjectExcelFileFixture.createDataRow(sheet);
+
+        SubjectSheetHeaderMapper subjectSheetHeaderMapper = new SubjectSheetHeaderMapper(headerRow);
+        ExcelSubject excelSubject = subjectSheetHeaderMapper.mapRowToSubject(dataRow);
+
+        assertAll(() -> assertThat(excelSubject.offeringUniversity()).isEqualTo("대양휴머니티칼리지"),
+            () -> assertThat(excelSubject.offeringDepartment()).isEqualTo("대양휴머니티칼리지"),
+            () -> assertThat(excelSubject.subjectNumber()).isEqualTo("009352"),
+            () -> assertThat(excelSubject.classDivision()).isEqualTo("001"),
+            () -> assertThat(excelSubject.subjectName()).isEqualTo("사고와표현1"),
+            () -> assertThat(excelSubject.subjectType()).isEqualTo("공통교양필수"),
+            () -> assertThat(excelSubject.electiveArea()).isEqualTo("학문기초"),
+            () -> assertThat(excelSubject.academicYearSemester()).isEqualTo("1"),
+            () -> assertThat(excelSubject.credit()).isEqualTo("3.0"),
+            () -> assertThat(excelSubject.theoryHours()).isEqualTo("3"),
+            () -> assertThat(excelSubject.practiceHours()).isEqualTo("0"),
+            () -> assertThat(excelSubject.classType()).isEqualTo("이론"),
+            () -> assertThat(excelSubject.exchangeEligible()).isEqualTo(""),
+            () -> assertThat(excelSubject.schedule()).isEqualTo("화 목 09:00~10:30"),
+            () -> assertThat(excelSubject.lectureRoom()).isEqualTo("세101"),
+            () -> assertThat(excelSubject.mainProfessor()).isEqualTo("노지현"),
+            () -> assertThat(excelSubject.supervisingDepartment()).isEqualTo("국어국문학과"),
+            () -> assertThat(excelSubject.notesAndRestrictions()).isEqualTo("외국인대상과목, 기초(Beginner)"),
+            () -> assertThat(excelSubject.classCategory()).isEqualTo(""),
+            () -> assertThat(excelSubject.onlineLecture()).isEqualTo(""),
+            () -> assertThat(excelSubject.lectureLanguage()).isEqualTo("영어"),
+            () -> assertThat(excelSubject.foreignerOnly()).isEqualTo("Y"),
+            () -> assertThat(excelSubject.domesticOnly()).isEqualTo(""));
+    }
+}

--- a/src/test/java/kr/allcll/seatfinder/excel/SubjectSheetParserTest.java
+++ b/src/test/java/kr/allcll/seatfinder/excel/SubjectSheetParserTest.java
@@ -1,0 +1,62 @@
+package kr.allcll.seatfinder.excel;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import java.io.IOException;
+import kr.allcll.seatfinder.support.fixture.SubjectExcelFileFixture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.multipart.MultipartFile;
+
+class SubjectSheetParserTest {
+
+    @DisplayName("과목 엑셀 파일을 파싱한다.")
+    @Test
+    void subjectSheetParserTest() throws IOException {
+        MultipartFile mockSubjectExcelFile = SubjectExcelFileFixture.createMockFile();
+        SubjectSheetParser subjectSheetParser = new SubjectSheetParser();
+
+        SubjectsParsingResponse subjectsParsingResponse = subjectSheetParser.parse(mockSubjectExcelFile);
+
+        assertThat(subjectsParsingResponse.excelSubjects()).hasSize(1);
+        ExcelSubject parsedSubject = subjectsParsingResponse.excelSubjects().getFirst();
+        assertAll(
+            () -> assertThat(parsedSubject.offeringUniversity()).isEqualTo("대양휴머니티칼리지"),
+            () -> assertThat(parsedSubject.offeringDepartment()).isEqualTo("대양휴머니티칼리지"),
+            () -> assertThat(parsedSubject.subjectNumber()).isEqualTo("009352"),
+            () -> assertThat(parsedSubject.classDivision()).isEqualTo("001"),
+            () -> assertThat(parsedSubject.subjectName()).isEqualTo("사고와표현1"),
+            () -> assertThat(parsedSubject.subjectType()).isEqualTo("공통교양필수"),
+            () -> assertThat(parsedSubject.electiveArea()).isEqualTo("학문기초"),
+            () -> assertThat(parsedSubject.academicYearSemester()).isEqualTo("1"),
+            () -> assertThat(parsedSubject.credit()).isEqualTo("3.0"),
+            () -> assertThat(parsedSubject.theoryHours()).isEqualTo("3"),
+            () -> assertThat(parsedSubject.practiceHours()).isEqualTo("0"),
+            () -> assertThat(parsedSubject.classType()).isEqualTo("이론"),
+            () -> assertThat(parsedSubject.exchangeEligible()).isEqualTo(""),
+            () -> assertThat(parsedSubject.schedule()).isEqualTo("화 목 09:00~10:30"),
+            () -> assertThat(parsedSubject.lectureRoom()).isEqualTo("세101"),
+            () -> assertThat(parsedSubject.mainProfessor()).isEqualTo("노지현"),
+            () -> assertThat(parsedSubject.supervisingDepartment()).isEqualTo("국어국문학과"),
+            () -> assertThat(parsedSubject.notesAndRestrictions()).isEqualTo("외국인대상과목, 기초(Beginner)"),
+            () -> assertThat(parsedSubject.classCategory()).isEqualTo(""),
+            () -> assertThat(parsedSubject.onlineLecture()).isEqualTo(""),
+            () -> assertThat(parsedSubject.lectureLanguage()).isEqualTo("영어"),
+            () -> assertThat(parsedSubject.foreignerOnly()).isEqualTo("Y"),
+            () -> assertThat(parsedSubject.domesticOnly()).isEqualTo("")
+        );
+    }
+
+    @DisplayName("과목 엑셀 파일을 파싱할 수 없는 경우 예외를 던진다.")
+    @Test
+    void subjectSheetParserTestWithWrongExtension() {
+        MultipartFile mockSubjectExcelFile = SubjectExcelFileFixture.createMockFileWithWrongExtension();
+        SubjectSheetParser subjectSheetParser = new SubjectSheetParser();
+
+        assertThatThrownBy(() -> subjectSheetParser.parse(mockSubjectExcelFile))
+            .isInstanceOf(IOException.class)
+            .hasMessage("지원하지 않는 파일 형식입니다. 입력한 파일 형식: txt");
+    }
+}

--- a/src/test/java/kr/allcll/seatfinder/subject/SubjectApiTest.java
+++ b/src/test/java/kr/allcll/seatfinder/subject/SubjectApiTest.java
@@ -25,15 +25,6 @@ class SubjectApiTest {
     @Autowired
     private MockMvc mockMvc;
 
-    /*
-        @PostMapping("/api/subject/upload")
-    public ResponseEntity<String> uploadSubjects(@RequestParam MultipartFile file) throws IOException {
-        SubjectsParsingResponse parsedSubjects = subjectSheetParser.parse(file);
-        SubjectsRequest subjectsRequest = SubjectsRequest.toSubjectsRequest(parsedSubjects);
-        subjectApp.save(subjectsRequest);
-        return ResponseEntity.ok("업로드에 성공했습니다.");
-    }
-     */
     @MockitoBean
     private SubjectSheetParser subjectSheetParser;
 

--- a/src/test/java/kr/allcll/seatfinder/subject/SubjectApiTest.java
+++ b/src/test/java/kr/allcll/seatfinder/subject/SubjectApiTest.java
@@ -1,0 +1,62 @@
+package kr.allcll.seatfinder.subject;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+import kr.allcll.seatfinder.excel.SubjectSheetParser;
+import kr.allcll.seatfinder.excel.SubjectsParsingResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.multipart.MultipartFile;
+
+@WebMvcTest(SubjectApi.class)
+class SubjectApiTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    /*
+        @PostMapping("/api/subject/upload")
+    public ResponseEntity<String> uploadSubjects(@RequestParam MultipartFile file) throws IOException {
+        SubjectsParsingResponse parsedSubjects = subjectSheetParser.parse(file);
+        SubjectsRequest subjectsRequest = SubjectsRequest.toSubjectsRequest(parsedSubjects);
+        subjectApp.save(subjectsRequest);
+        return ResponseEntity.ok("업로드에 성공했습니다.");
+    }
+     */
+    @MockitoBean
+    private SubjectSheetParser subjectSheetParser;
+
+    @MockitoBean
+    private SubjectApp subjectApp;
+
+    @DisplayName("과목 엑셀 파일을 업로드한다.")
+    @Test
+    void uploadSubjectsApiTest() throws Exception {
+        MockMultipartFile mockFile = new MockMultipartFile(
+            "file",
+            "subjects.xlsx",
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            "dummy-content".getBytes()
+        );
+        SubjectsParsingResponse mockResponse = new SubjectsParsingResponse(List.of());
+        given(subjectSheetParser.parse(any(MultipartFile.class))).willReturn(mockResponse);
+
+        mockMvc.perform(multipart("/api/subject/upload").file(mockFile))
+            .andExpect(status().isOk())
+            .andExpect(content().string("업로드에 성공했습니다."));
+
+        then(subjectSheetParser).should().parse(any(MultipartFile.class));
+        then(subjectApp).should().save(any(SubjectsRequest.class));
+    }
+}

--- a/src/test/java/kr/allcll/seatfinder/subject/SubjectApiTest.java
+++ b/src/test/java/kr/allcll/seatfinder/subject/SubjectApiTest.java
@@ -29,7 +29,7 @@ class SubjectApiTest {
     private SubjectSheetParser subjectSheetParser;
 
     @MockitoBean
-    private SubjectApp subjectApp;
+    private SubjectService subjectService;
 
     @DisplayName("과목 엑셀 파일을 업로드한다.")
     @Test
@@ -48,6 +48,6 @@ class SubjectApiTest {
             .andExpect(content().string("업로드에 성공했습니다."));
 
         then(subjectSheetParser).should().parse(any(MultipartFile.class));
-        then(subjectApp).should().save(any(SubjectsRequest.class));
+        then(subjectService).should().save(any(SubjectsRequest.class));
     }
 }

--- a/src/test/java/kr/allcll/seatfinder/support/fixture/SubjectExcelFileFixture.java
+++ b/src/test/java/kr/allcll/seatfinder/support/fixture/SubjectExcelFileFixture.java
@@ -1,0 +1,68 @@
+package kr.allcll.seatfinder.support.fixture;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.stream.IntStream;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.xssf.usermodel.XSSFSheet;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+
+public class SubjectExcelFileFixture {
+
+    private static final String[] SUBJECT_HEADERS = {"순번", "개설대학", "개설학과전공", "학수번호", "분반", "교과목명", "이수구분", "선택영역",
+        "학년\n(학기)", "학점", "이론", "실습", "수업\n유형", "학점교류\n수강가능", "요일 및 강의시간", "강의실", "메인\n교수명", "주관학과", "수강대상및유의사항",
+        "강좌유형", "사이버강좌", "강의언어", "외국인\n전용", "내국인\n전용"};
+
+    private static final String[] SUBJECT_DATA = {"1", "대양휴머니티칼리지", "대양휴머니티칼리지", "009352", "001", "사고와표현1",
+        "공통교양필수", "학문기초", "1", "3.0", "3", "0", "이론", "", "화 목 09:00~10:30", "세101", "노지현", "국어국문학과",
+        "외국인대상과목, 기초(Beginner)", "", "", "영어", "Y", ""};
+
+
+    public static MultipartFile createMockFile() throws IOException {
+        XSSFWorkbook workbook = new XSSFWorkbook();
+        XSSFSheet sheet = workbook.createSheet("개설강좌");
+        createHeaderRow(sheet);
+        createDataRow(sheet);
+        InputStream excelInputStream = createInputStream(workbook);
+        return new MockMultipartFile(
+            "2024-2강의시간표(한국어)_20240809",
+            "2024-2강의시간표(한국어)_20240809.xlsx",
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            excelInputStream
+        );
+    }
+
+    public static Row createHeaderRow(XSSFSheet sheet) {
+        Row headerRow = sheet.createRow(0);
+        IntStream.range(0, SUBJECT_HEADERS.length)
+            .forEach(i -> headerRow.createCell(i).setCellValue(SUBJECT_HEADERS[i]));
+        return headerRow;
+    }
+
+    public static Row createDataRow(XSSFSheet sheet) {
+        Row dataRow = sheet.createRow(1);
+        IntStream.range(0, SUBJECT_DATA.length)
+            .forEach(i -> dataRow.createCell(i).setCellValue(SUBJECT_DATA[i]));
+        return dataRow;
+    }
+
+    private static InputStream createInputStream(XSSFWorkbook workbook) throws IOException {
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        workbook.write(outputStream);
+        workbook.close();
+        return new ByteArrayInputStream(outputStream.toByteArray());
+    }
+
+    public static MultipartFile createMockFileWithWrongExtension() {
+        return new MockMultipartFile(
+            "file",
+            "subjects.txt",
+            "application/vnd.ms-excel",
+            "test".getBytes()
+        );
+    }
+}


### PR DESCRIPTION
## 작업 내용

과목 엑셀파일을 업로드하는 기능을 구현했어요! 매학기마다 개설과목을 엑셀 파일로 공개하는데, 엑셀 파일을 업로드하면 자동으로 데이터베이스에 등록되도록 했습니다. 매우 편리한 기능입니다. 베이스 코드 없이 구현했기에 PR 내용이 다소 많은 점, 양해 부탁드려요. 

- 엑셀을 다루는 데에 Apache POI 라이브러리를 사용했어요. 자바 진영에서 가장 많이 사용하는 라이브러리라고 해요. 
- 엑셀을 직접 다루는 작업은 `excel` 패키지에 과목을 다루는 작업은 `subject` 패키지로 나누었어요. 의존성 방향은 (`subject` -> `excel`)으로 정했고, 의존성 분리를 위해 DTO를 여럿 만들었어요. 

### 엑셀 파싱 구현

엑셀 파일은 다음과 같이 구성되어 있어요. 24-2학기 엑셀 파일은 [여기](https://board.sejong.ac.kr/boardview.do?pkid=164996&currentPage=4&searchField=D.TITLE&siteGubun=19&menuGubun=1&bbsConfigFK=335&searchLowItem=ALL&searchValue=2%ED%95%99%EA%B8%B0)에서 다운받을 수 있어요. 

<img width="929" alt="스크린샷 2025-01-19 오후 5 20 45" src="https://github.com/user-attachments/assets/ff01e830-efb3-43d1-b03d-9c3e7d0aae3d" />

엑셀 파일의 상단, 컬럼명을 `SubjectHeader`라는 이름으로 코드에 작성해 두었어요. 참고 부탁해요! 엑셀 시트를 파싱하는 방식은 다음과 같아요. 

1. 헤더 컬럼을 파싱한다. 
2. 헤더를 구성한다. 
3. 데이터 컬럼들을 파싱한다. 
4. 파싱한 데이터로 `Subject` 객체를 만든다. 

여기서 까다로운 부분이 파싱한 데이터를 올바르게 `Subject` 객체로 변환하는 거였어요. 고민한 첫 번째는 [1] `대양휴머니티컬리지`라는 값을 `Subject`의 `offeringUniversity` 필드로 어떻게 매핑할 것인가? 하는 부분이 어려웠어요. 그리고 [2] 수많은 필드를 가지고 어떻게 객체를 생성하는 게 좋을지 고민했어요. 

우선 [2]에 대해서는 **생성자**로 객체를 생성하는 방법과 **Setter**를 사용하거나, **Builder**를 사용하는 방법을 고민했어요. 결론적으로 Builder를 사용했는데요. 이것은 [1]에 대한 고민을 해결하던 과정에서 결정한 방식이에요. 

[1]은 파싱한 값을 `Subject` 객체의 적절한 필드에 주입해야 하는 문제에요. 우려되는 문제는 개설대학 필드에 교과목명이 대입되는 상황이에요. 이것은 어쩔 수 없이 인덱스에 의존하는 방향으로 구현했어요. 대신 코드를 예쁘게 만들기 위해 여러 노력을 했어요! 그 과정에서 `SubjectSheetHeader`와 `SubjectSheetHeaderMapper` 등의 객체를 추가했는데, 오히려 더 복잡해졌나 싶은 생각도 있어요. 리플렉션 등을 사용해서 더 개선하고 싶은 욕심은 있지만 지금은 다른 태스크가 급해서 이정도로 마무리 했어요. 

### excel 패키지와 subject 패키지의 의존성

`subject`가 `excel`을 사용하는 구조이기 때문에 의존성 방향을 subject -> excel로 잡았어요. 의존성 분리를 위해 `excel.ExcelSubject`, `excel.SubjectsParsingResponse`, `subject.SubjectRequest`, `subject.SubjectsRequest`와 같은 dto성 객체가 추가되었어요. 잘 살펴보면 모두 의존성 방향을 지키는 걸 확인할 수 있어요. 


## 리뷰 포인트
베이스 코드가 많이 추가되어서, 리뷰할 포인트가 상당히 많아요. 너무 리뷰양이 많다면 `subject` 패키지만 해도 괜찮을 것 같아요. 중요한 api가 아니기 때문이에요! 
전반적으로 검토하면서 궁금한 것, 개선이 필요한 부분 가감없이 해주세요! 특히 리뷰가 필요한 부분은 아래에 남겼어요. 

- Subject 객체의 필드명과 주석 적절한가요? 
- `SubjectApi`, `SubjectApp` 이라는 네이밍 괜찮은가요? 
- `SubjectApi`는 웹 계층에 대해서만 슬라이스 테스트를 진행했어요. 요청과 응답이 적절한지만 검토한 건데, 이미 의존하고 있는 다른 클래스에 대한 테스트가 충분히 이루어 지고 있기에 슬라이스 테스트만 해도 괜찮다고 생각했어요. 이 방식에 대해 어떻게 생각하시나요? 괜찮다면 앞으로 API 클래스는 슬라이스 테스트만 진행해도 괜찮을까요? 
- `SubjectApp`은 위임 메서드 밖에 없어서 테스트 코드를 작성하지 않았어요! 
- 공통 예외 클래스를 아직 정의하지 않아서, 일단 임의의 표준 예외 클래스를 사용했어요.
- 로그 남긴 부분이 적절한지 궁금해요! `SubjectSheetHeaderMapper`, `SubjectSheetParser`에 남겨두었어요. 
- 이번에 구현한 API는 어드민만 접근 가능한 API로 추후 이에 대한 처리가 필요합니다. 