### PR TITLE
fix: 빠뜨린 import문 추가

### DIFF
--- a/src/main/java/kr/allcll/seatfinder/subject/SubjectApi.java
+++ b/src/main/java/kr/allcll/seatfinder/subject/SubjectApi.java
@@ -3,6 +3,7 @@ package kr.allcll.seatfinder.subject;
 import java.io.IOException;
 import kr.allcll.seatfinder.excel.SubjectSheetParser;
 import kr.allcll.seatfinder.excel.SubjectsParsingResponse;
+import kr.allcll.seatfinder.subject.dto.SubjectsRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;

--- a/src/main/java/kr/allcll/seatfinder/subject/SubjectService.java
+++ b/src/main/java/kr/allcll/seatfinder/subject/SubjectService.java
@@ -1,6 +1,7 @@
 package kr.allcll.seatfinder.subject;
 
 import java.util.List;
+import kr.allcll.seatfinder.subject.dto.SubjectsRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 


### PR DESCRIPTION
## 작업 내용

이전 PR에서 변경 내용 중 추가하지 못한 내용이 있었어요. 
dto들을 dto 패키지로 분리할 때, dto에 의존하던 클래스의 import 문을 커밋에 넣지 못했어요. 
재발 방지를 위해 ci를 두어야겠어요. 