### PR TITLE
feat: SSE 연결 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ dependencies {
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'io.rest-assured:rest-assured:5.5.0'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/src/main/java/kr/allcll/seatfinder/sse/SseApi.java
+++ b/src/main/java/kr/allcll/seatfinder/sse/SseApi.java
@@ -1,0 +1,20 @@
+package kr.allcll.seatfinder.sse;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@RestController
+@RequiredArgsConstructor
+public class SseApi {
+
+    private final SseService sseService;
+
+    @GetMapping(value = "/api/connect", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public ResponseEntity<SseEmitter> getServerSentEventConnection() {
+        return ResponseEntity.ok(sseService.connect());
+    }
+}

--- a/src/main/java/kr/allcll/seatfinder/sse/SseEmitterStorage.java
+++ b/src/main/java/kr/allcll/seatfinder/sse/SseEmitterStorage.java
@@ -1,0 +1,23 @@
+package kr.allcll.seatfinder.sse;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@Component
+public class SseEmitterStorage {
+
+    /*
+        ExecutorService로 변경이 필요할 수 있습니다.
+     */
+    private final List<SseEmitter> emitters;
+
+    public SseEmitterStorage() {
+        this.emitters = new ArrayList<>();
+    }
+
+    public void add(SseEmitter sseEmitter) {
+        emitters.add(sseEmitter);
+    }
+}

--- a/src/main/java/kr/allcll/seatfinder/sse/SseEmitterStorage.java
+++ b/src/main/java/kr/allcll/seatfinder/sse/SseEmitterStorage.java
@@ -19,5 +19,6 @@ public class SseEmitterStorage {
 
     public void add(SseEmitter sseEmitter) {
         emitters.add(sseEmitter);
+        sseEmitter.onCompletion(() -> emitters.remove(sseEmitter));
     }
 }

--- a/src/main/java/kr/allcll/seatfinder/sse/SseService.java
+++ b/src/main/java/kr/allcll/seatfinder/sse/SseService.java
@@ -1,0 +1,43 @@
+package kr.allcll.seatfinder.sse;
+
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter.SseEventBuilder;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SseService {
+
+    private static final long SSE_TIMEOUT_MILLIS = 60 * 1000;
+
+    private final SseEmitterStorage sseEmitterStorage;
+
+    public SseEmitter connect() {
+        SseEmitter sseEmitter = createSseEmitter();
+        sseEmitterStorage.add(sseEmitter);
+        sendInitialEvent(sseEmitter);
+        return sseEmitter;
+    }
+
+    protected SseEmitter createSseEmitter() {
+        return new SseEmitter(SSE_TIMEOUT_MILLIS);
+    }
+
+    private void sendInitialEvent(SseEmitter sseEmitter) {
+        try {
+            sseEmitter.send(initialEvent());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private SseEventBuilder initialEvent() {
+        return SseEmitter.event()
+            .name("connection")
+            .data("success");
+    }
+}

--- a/src/main/java/kr/allcll/seatfinder/sse/SseService.java
+++ b/src/main/java/kr/allcll/seatfinder/sse/SseService.java
@@ -2,12 +2,10 @@ package kr.allcll.seatfinder.sse;
 
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter.SseEventBuilder;
 
-@Slf4j
 @Service
 @RequiredArgsConstructor
 public class SseService {

--- a/src/test/java/kr/allcll/seatfinder/sse/SseApiTest.java
+++ b/src/test/java/kr/allcll/seatfinder/sse/SseApiTest.java
@@ -1,0 +1,31 @@
+package kr.allcll.seatfinder.sse;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(SseApi.class)
+class SseApiTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private SseService sseService;
+
+    @DisplayName("Server Sent Event를 연결한다.")
+    @Test
+    void getServerSentEventConnection() throws Exception {
+        // when, then
+        mockMvc.perform(get("/api/connect")
+                .accept(MediaType.TEXT_EVENT_STREAM_VALUE))
+            .andExpect(status().isOk());
+    }
+}

--- a/src/test/java/kr/allcll/seatfinder/sse/SseIntegrationTest.java
+++ b/src/test/java/kr/allcll/seatfinder/sse/SseIntegrationTest.java
@@ -1,0 +1,89 @@
+package kr.allcll.seatfinder.sse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import io.restassured.RestAssured;
+import io.restassured.response.Response;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.StringReader;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+class SseIntegrationTest {
+
+    private static final Logger log = LoggerFactory.getLogger(SseIntegrationTest.class);
+
+    @MockitoSpyBean
+    private SseService sseService;
+
+    @LocalServerPort
+    private int port;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+    }
+
+    @DisplayName("SSE를 연결하고, 최초 메시지를 받는다.")
+    @Test
+    void sseConnectionTest() {
+        long mockSseEmitterTimeout = 500L;
+        when(sseService.createSseEmitter()).thenReturn(new SseEmitter(mockSseEmitterTimeout));
+
+        // when
+        Response response = RestAssured.given()
+            .accept("text/event-stream")
+            .when()
+            .get("/api/connect")
+            .then()
+            .statusCode(200)
+            .extract()
+            .response();
+
+        // then
+        SseTestHelper.assertResponseContainsMessage(response, "success");
+    }
+
+    private static class SseTestHelper {
+
+        private static final long TIMEOUT = 1000;
+
+        public static void assertResponseContainsMessage(Response response, String message) {
+            String body = response.getBody().asString();
+            try (BufferedReader reader = new BufferedReader(new StringReader(body))) {
+                String eventReceived = readResponse(reader, message);
+                assertThat(eventReceived).contains(message);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        private static String readResponse(BufferedReader reader, String message) throws IOException {
+            StringBuilder lines = new StringBuilder();
+            String line;
+            long startTime = System.currentTimeMillis();
+            while ((line = reader.readLine()) != null) {
+                log.info("Received: {}", line);
+                lines.append(line).append("\n");
+                if (line.startsWith(message)) {
+                    break;
+                }
+                if (System.currentTimeMillis() - startTime > TIMEOUT) {
+                    break;
+                }
+            }
+            return lines.toString();
+        }
+    }
+}


### PR DESCRIPTION
## 작업 내용

- SSE 연결하는 기능을 구현하고 API를 만들었어요. 

SSE에 대한 이해가 있어야 코드를 이해하기 쉬울 것 같아요. 제가 참고한 글은 [Tecoble](https://tecoble.techcourse.co.kr/post/2022-10-11-server-sent-events/)이에요! PR을 이해하기 위해 SSE에 대해 반드시 알아야 할 부분은 다음과 같아요. 

- SSE 연결을 맺고 타임아웃 전까지 아무런 메시지를 보내지 않으면 503 에러를 받는다. 
- SSE 연결이 많아지면 SSE 메시지를 보내기 위한 스레드가 늘어난다. 이것이 병목 또는 장애를 유발할 수 있다. 

SSE 테스트가 좀 어렵더라고요. 레퍼런스도 찾지 못했어요. 만약 찾게 된다면 알려주시면 감사합니다 🙇 

## 고민 지점과 리뷰 포인트

### SSE 테스트하면서 고민했던 부분

SSE 테스트는 슬라이스로 진행하기에 다소 의미가 없다고 생각했어요. SSE 연결에 대해 통합 테스트(E2E 테스트이려나..)를 작성했고, 앞으로도 그럴 생각이에요! 테스트를 작성하면서 RestAssured를 사용했어요! 이것이 완전히 사용자의 요청과 유사한 테스트를 작성할 수 있다고 생각했기 때문이에요. RestAssured로 테스트를 작성했지만 SSE를 테스트하는 건 쉽지 않았어요. SSE로 메시지를 받아도 바로 연결이 끊기는 것은 아니었고,  RestAssured는 연결이 끊길 때까지 대기해요. 그래서 테스트 실행 시간이 굉장히 길어졌어요. SseEmitter를 생성할 때 연결 시간을 설정할 수 있는데, 이렇게 설정한 시간만큼 테스트가 대기하더군요. 그래서 SseService 메서드를 모킹해서 연결 시간이 짧은 SseEmitter를 생성하도록 했어요.  

### 리뷰 포인트

- 테스트에서 모킹한 SseEmitter를 생성할 때 현재는 500밀리초로 설정했어요. 이것이 적절할까요? 사실 많이 길다고 생각하는데 더 줄이면 환경에 따라 실패하는 테스트가 될까봐 두렵네요. 
- SseEmitter 생성을 모킹하기 위해 어쩔 수 없이 SseService의 createSseEmitter 메서드를 protected로 열었는데요. 정말 별로지만 개발이 급하기에 선택한 방법이에요. 
