### PR TITLE
feat: 커스텀 예외 및 추가 GlobalExceptionHandler 적용

### DIFF
--- a/src/main/java/kr/allcll/seatfinder/exception/AllcllErrorCode.java
+++ b/src/main/java/kr/allcll/seatfinder/exception/AllcllErrorCode.java
@@ -1,6 +1,6 @@
 package kr.allcll.seatfinder.exception;
 
-public enum ExceptionMessage {
+public enum AllcllErrorCode {
 
     MAX_PIN_EXCEPTION("이미 %d개의 핀을 등록했습니다."),
     EXIST_PIN_EXCEPTION("이미 핀 등록된 과목입니다."),
@@ -9,7 +9,7 @@ public enum ExceptionMessage {
 
     private String message;
 
-    ExceptionMessage(String message) {
+    AllcllErrorCode(String message) {
         this.message = message;
     }
 

--- a/src/main/java/kr/allcll/seatfinder/exception/AllcllErrorCode.java
+++ b/src/main/java/kr/allcll/seatfinder/exception/AllcllErrorCode.java
@@ -2,10 +2,10 @@ package kr.allcll.seatfinder.exception;
 
 public enum AllcllErrorCode {
 
-    MAX_PIN_EXCEPTION("이미 %d개의 핀을 등록했습니다."),
-    EXIST_PIN_EXCEPTION("이미 핀 등록된 과목입니다."),
-    PIN_AND_SUBJECT_NOT_MATCH("핀에 등록된 과목이 아닙니다."),
-    NOT_EXIST_SUBJECT("존재하지 않는 과목 입니다.");
+    PIN_LIMIT_EXCEEDED("이미 %d개의 핀을 등록했습니다."),
+    DUPLICATE_PIN("%s은(는) 이미 핀 등록된 과목입니다."),
+    PIN_SUBJECT_MISMATCH("핀에 등록된 과목이 아닙니다."),
+    SUBJECT_NOT_FOUND("존재하지 않는 과목 입니다.");
 
     private String message;
 

--- a/src/main/java/kr/allcll/seatfinder/exception/AllcllException.java
+++ b/src/main/java/kr/allcll/seatfinder/exception/AllcllException.java
@@ -1,5 +1,8 @@
 package kr.allcll.seatfinder.exception;
 
+import lombok.Getter;
+
+@Getter
 public class AllcllException extends RuntimeException {
 
     private final String errorCode;
@@ -7,10 +10,6 @@ public class AllcllException extends RuntimeException {
     public AllcllException(String message, String errorCode) {
         super(message);
         this.errorCode = errorCode;
-    }
-
-    public String getErrorCode() {
-        return errorCode;
     }
 
     public static AllcllException from(ExceptionMessage e) {

--- a/src/main/java/kr/allcll/seatfinder/exception/AllcllException.java
+++ b/src/main/java/kr/allcll/seatfinder/exception/AllcllException.java
@@ -7,17 +7,13 @@ public class AllcllException extends RuntimeException {
 
     private final String errorCode;
 
-    public AllcllException(String message, String errorCode) {
-        super(message);
-        this.errorCode = errorCode;
+    public AllcllException(AllcllErrorCode e) {
+        super(e.getMessage());
+        this.errorCode = e.name();
     }
 
-    public static AllcllException from(ExceptionMessage e) {
-        return new AllcllException(e.getMessage(), e.name());
-    }
-
-    public static AllcllException of(int number, ExceptionMessage e) {
-        String exceptionMessage = String.format(e.getMessage(), number);
-        return new AllcllException(exceptionMessage, e.name());
+    public AllcllException(AllcllErrorCode e, Object... args) {
+        super(String.format(e.getMessage(), args));
+        this.errorCode = e.name();
     }
 }

--- a/src/main/java/kr/allcll/seatfinder/exception/AllcllException.java
+++ b/src/main/java/kr/allcll/seatfinder/exception/AllcllException.java
@@ -7,13 +7,18 @@ public class AllcllException extends RuntimeException {
 
     private final String errorCode;
 
-    public AllcllException(AllcllErrorCode e) {
-        super(e.getMessage());
-        this.errorCode = e.name();
+    public AllcllException(AllcllErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode.name();
     }
 
-    public AllcllException(AllcllErrorCode e, Object... args) {
-        super(String.format(e.getMessage(), args));
-        this.errorCode = e.name();
+    public AllcllException(String message, Throwable cause, AllcllErrorCode errorCode) {
+        super(message, cause);
+        this.errorCode = errorCode.name();
+    }
+
+    public AllcllException(AllcllErrorCode errorCode, Object... args) {
+        super(String.format(errorCode.getMessage(), args));
+        this.errorCode = errorCode.name();
     }
 }

--- a/src/main/java/kr/allcll/seatfinder/exception/AllcllException.java
+++ b/src/main/java/kr/allcll/seatfinder/exception/AllcllException.java
@@ -1,0 +1,24 @@
+package kr.allcll.seatfinder.exception;
+
+public class AllcllException extends RuntimeException {
+
+    private final String errorCode;
+
+    public AllcllException(String message, String errorCode) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+
+    public String getErrorCode() {
+        return errorCode;
+    }
+
+    public static AllcllException from(ExceptionMessage e) {
+        return new AllcllException(e.getMessage(), e.name());
+    }
+
+    public static AllcllException of(int number, ExceptionMessage e) {
+        String exceptionMessage = String.format(e.getMessage(), number);
+        return new AllcllException(exceptionMessage, e.name());
+    }
+}

--- a/src/main/java/kr/allcll/seatfinder/exception/ErrorResponse.java
+++ b/src/main/java/kr/allcll/seatfinder/exception/ErrorResponse.java
@@ -1,0 +1,9 @@
+package kr.allcll.seatfinder.exception;
+
+public record ErrorResponse(
+    String code,
+    String message,
+    String status
+) {
+
+}

--- a/src/main/java/kr/allcll/seatfinder/exception/ExceptionMessage.java
+++ b/src/main/java/kr/allcll/seatfinder/exception/ExceptionMessage.java
@@ -1,0 +1,19 @@
+package kr.allcll.seatfinder.exception;
+
+public enum ExceptionMessage {
+
+    MAX_PIN_EXCEPTION("이미 %d개의 핀을 등록했습니다."),
+    EXIST_PIN_EXCEPTION("이미 핀 등록된 과목입니다."),
+    PIN_AND_SUBJECT_NOT_MATCH("핀에 등록된 과목이 아닙니다."),
+    NOT_EXIST_SUBJECT("존재하지 않는 과목 입니다.");
+
+    private String message;
+
+    ExceptionMessage(String message) {
+        this.message = message;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/kr/allcll/seatfinder/exception/GlobalExceptionHandler.java
+++ b/src/main/java/kr/allcll/seatfinder/exception/GlobalExceptionHandler.java
@@ -1,0 +1,51 @@
+package kr.allcll.seatfinder.exception;
+
+import jakarta.servlet.http.HttpServletRequest;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    private static final String LOG_FORMAT = """
+        \n\t{
+            "RequestURI": "{} {}",
+            "RequestBody": {},
+            "ErrorMessage": "{}"
+        \t}
+        """;
+
+    @ExceptionHandler
+    public ResponseEntity<ErrorResponse> handleAllcllException(HttpServletRequest request, AllcllException e) {
+        log.warn(LOG_FORMAT, request.getMethod(), request.getRequestURI(), getRequestBody(request), e.getMessage());
+        return ResponseEntity.badRequest()
+            .body(new ErrorResponse(e.getErrorCode(),
+                e.getMessage(),
+                HttpStatus.BAD_REQUEST.toString()));
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<ErrorResponse> handleException(HttpServletRequest request, Exception e) {
+        log.error(LOG_FORMAT, request.getMethod(), request.getRequestURI(), getRequestBody(request), e.getMessage());
+        return ResponseEntity.internalServerError()
+            .body(new ErrorResponse("SERVER_ERROR",
+                "서버 에러가 발생하였습니다.",
+                HttpStatus.INTERNAL_SERVER_ERROR.toString()));
+    }
+
+    private String getRequestBody(HttpServletRequest request) {
+        try (BufferedReader reader = request.getReader()) {
+            return reader.lines().collect(Collectors.joining(System.lineSeparator() + "\t"));
+        } catch (IOException e) {
+            log.error("Failed to read request body", e);
+            return "";
+        }
+    }
+}

--- a/src/main/java/kr/allcll/seatfinder/pin/PinService.java
+++ b/src/main/java/kr/allcll/seatfinder/pin/PinService.java
@@ -23,26 +23,26 @@ public class PinService {
     public void addPinOnSubject(Long subjectId, String token) {
         List<Pin> userPins = pinRepository.findAllByToken(token);
         Subject subject = subjectRepository.findById(subjectId)
-            .orElseThrow(() -> new AllcllException(AllcllErrorCode.NOT_EXIST_SUBJECT));
+            .orElseThrow(() -> new AllcllException(AllcllErrorCode.SUBJECT_NOT_FOUND));
         validateCanAddPin(userPins, subject, token);
         pinRepository.save(new Pin(token, subject));
     }
 
     private void validateCanAddPin(List<Pin> userPins, Subject subject, String token) {
         if (userPins.size() >= MAX_PIN_NUMBER) {
-            throw new AllcllException(AllcllErrorCode.MAX_PIN_EXCEPTION, MAX_PIN_NUMBER);
+            throw new AllcllException(AllcllErrorCode.PIN_LIMIT_EXCEEDED, MAX_PIN_NUMBER);
         }
         if (pinRepository.findBySubjectAndToken(subject, token).isPresent()) {
-            throw new AllcllException(AllcllErrorCode.EXIST_PIN_EXCEPTION);
+            throw new AllcllException(AllcllErrorCode.DUPLICATE_PIN, subject.getSubjectName());
         }
     }
 
     @Transactional
     public void deletePinOnSubject(Long subjectId, String token) {
         Subject subject = subjectRepository.findById(subjectId)
-            .orElseThrow(() -> new AllcllException(AllcllErrorCode.NOT_EXIST_SUBJECT));
+            .orElseThrow(() -> new AllcllException(AllcllErrorCode.SUBJECT_NOT_FOUND));
         Pin pin = pinRepository.findBySubjectAndToken(subject, token)
-            .orElseThrow(() -> new AllcllException(AllcllErrorCode.PIN_AND_SUBJECT_NOT_MATCH));
+            .orElseThrow(() -> new AllcllException(AllcllErrorCode.PIN_SUBJECT_MISMATCH));
         pinRepository.deleteById(pin.getId());
     }
 }

--- a/src/main/java/kr/allcll/seatfinder/pin/PinService.java
+++ b/src/main/java/kr/allcll/seatfinder/pin/PinService.java
@@ -1,6 +1,8 @@
 package kr.allcll.seatfinder.pin;
 
 import java.util.List;
+import kr.allcll.seatfinder.exception.AllcllException;
+import kr.allcll.seatfinder.exception.ExceptionMessage;
 import kr.allcll.seatfinder.subject.Subject;
 import kr.allcll.seatfinder.subject.SubjectRepository;
 import lombok.RequiredArgsConstructor;
@@ -21,26 +23,26 @@ public class PinService {
     public void addPinOnSubject(Long subjectId, String token) {
         List<Pin> userPins = pinRepository.findAllByToken(token);
         Subject subject = subjectRepository.findById(subjectId)
-            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 과목 입니다."));
+            .orElseThrow(() -> AllcllException.from(ExceptionMessage.NOT_EXIST_SUBJECT));
         validateCanAddPin(userPins, subject, token);
         pinRepository.save(new Pin(token, subject));
     }
 
     private void validateCanAddPin(List<Pin> userPins, Subject subject, String token) {
         if (userPins.size() >= MAX_PIN_NUMBER) {
-            throw new IllegalArgumentException(String.format("이미 %d개의 핀을 등록했습니다.", MAX_PIN_NUMBER));
+            throw AllcllException.of(MAX_PIN_NUMBER, ExceptionMessage.MAX_PIN_EXCEPTION);
         }
         if (pinRepository.findBySubjectAndToken(subject, token).isPresent()) {
-            throw new IllegalArgumentException("이미 핀 등록된 과목 입니다.");
+            throw AllcllException.from(ExceptionMessage.EXIST_PIN_EXCEPTION);
         }
     }
 
     @Transactional
     public void deletePinOnSubject(Long subjectId, String token) {
         Subject subject = subjectRepository.findById(subjectId)
-            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 과목 입니다."));
+            .orElseThrow(() -> AllcllException.from(ExceptionMessage.NOT_EXIST_SUBJECT));
         Pin pin = pinRepository.findBySubjectAndToken(subject, token)
-            .orElseThrow(() -> new IllegalArgumentException("핀에 등록된 과목이 아닙니다."));
+            .orElseThrow(() -> AllcllException.from(ExceptionMessage.PIN_AND_SUBJECT_NOT_MATCH));
         pinRepository.deleteById(pin.getId());
     }
 }

--- a/src/main/java/kr/allcll/seatfinder/pin/PinService.java
+++ b/src/main/java/kr/allcll/seatfinder/pin/PinService.java
@@ -1,8 +1,8 @@
 package kr.allcll.seatfinder.pin;
 
 import java.util.List;
+import kr.allcll.seatfinder.exception.AllcllErrorCode;
 import kr.allcll.seatfinder.exception.AllcllException;
-import kr.allcll.seatfinder.exception.ExceptionMessage;
 import kr.allcll.seatfinder.subject.Subject;
 import kr.allcll.seatfinder.subject.SubjectRepository;
 import lombok.RequiredArgsConstructor;
@@ -23,26 +23,26 @@ public class PinService {
     public void addPinOnSubject(Long subjectId, String token) {
         List<Pin> userPins = pinRepository.findAllByToken(token);
         Subject subject = subjectRepository.findById(subjectId)
-            .orElseThrow(() -> AllcllException.from(ExceptionMessage.NOT_EXIST_SUBJECT));
+            .orElseThrow(() -> new AllcllException(AllcllErrorCode.NOT_EXIST_SUBJECT));
         validateCanAddPin(userPins, subject, token);
         pinRepository.save(new Pin(token, subject));
     }
 
     private void validateCanAddPin(List<Pin> userPins, Subject subject, String token) {
         if (userPins.size() >= MAX_PIN_NUMBER) {
-            throw AllcllException.of(MAX_PIN_NUMBER, ExceptionMessage.MAX_PIN_EXCEPTION);
+            throw new AllcllException(AllcllErrorCode.MAX_PIN_EXCEPTION, MAX_PIN_NUMBER);
         }
         if (pinRepository.findBySubjectAndToken(subject, token).isPresent()) {
-            throw AllcllException.from(ExceptionMessage.EXIST_PIN_EXCEPTION);
+            throw new AllcllException(AllcllErrorCode.EXIST_PIN_EXCEPTION);
         }
     }
 
     @Transactional
     public void deletePinOnSubject(Long subjectId, String token) {
         Subject subject = subjectRepository.findById(subjectId)
-            .orElseThrow(() -> AllcllException.from(ExceptionMessage.NOT_EXIST_SUBJECT));
+            .orElseThrow(() -> new AllcllException(AllcllErrorCode.NOT_EXIST_SUBJECT));
         Pin pin = pinRepository.findBySubjectAndToken(subject, token)
-            .orElseThrow(() -> AllcllException.from(ExceptionMessage.PIN_AND_SUBJECT_NOT_MATCH));
+            .orElseThrow(() -> new AllcllException(AllcllErrorCode.PIN_AND_SUBJECT_NOT_MATCH));
         pinRepository.deleteById(pin.getId());
     }
 }

--- a/src/test/java/kr/allcll/seatfinder/pin/PinServiceTest.java
+++ b/src/test/java/kr/allcll/seatfinder/pin/PinServiceTest.java
@@ -4,8 +4,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.List;
-import kr.allcll.seatfinder.exception.AllcllException;
 import kr.allcll.seatfinder.exception.AllcllErrorCode;
+import kr.allcll.seatfinder.exception.AllcllException;
 import kr.allcll.seatfinder.subject.Subject;
 import kr.allcll.seatfinder.subject.SubjectRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -77,7 +77,7 @@ class PinServiceTest {
         // when, then
         assertThatThrownBy(() -> pinService.addPinOnSubject(overCountSubject.getId(), TOKEN))
             .isInstanceOf(AllcllException.class)
-            .hasMessageContaining(String.format(AllcllErrorCode.MAX_PIN_EXCEPTION.getMessage(), MAX_PIN_NUMBER));
+            .hasMessageContaining(String.format(AllcllErrorCode.PIN_LIMIT_EXCEEDED.getMessage(), MAX_PIN_NUMBER));
     }
 
 
@@ -88,11 +88,12 @@ class PinServiceTest {
         Subject subject = createSubject("컴퓨터구조", "003278", "001", "김보예");
         subjectRepository.save(subject);
         pinRepository.save(new Pin(TOKEN, subject));
+        String expectExceptionMessage = new AllcllException(AllcllErrorCode.DUPLICATE_PIN, "컴퓨터구조").getMessage();
 
         // when, then
         assertThatThrownBy(() -> pinService.addPinOnSubject(subject.getId(), TOKEN))
             .isInstanceOf(AllcllException.class)
-            .hasMessageContaining(AllcllErrorCode.EXIST_PIN_EXCEPTION.getMessage());
+            .hasMessageContaining(expectExceptionMessage);
     }
 
     @Test
@@ -123,7 +124,7 @@ class PinServiceTest {
         // when, then
         assertThatThrownBy(() -> pinService.deletePinOnSubject(notPinnedSubject.getId(), token))
             .isInstanceOf(AllcllException.class)
-            .hasMessageContaining(AllcllErrorCode.PIN_AND_SUBJECT_NOT_MATCH.getMessage());
+            .hasMessageContaining(AllcllErrorCode.PIN_SUBJECT_MISMATCH.getMessage());
     }
 
     @Test
@@ -136,7 +137,7 @@ class PinServiceTest {
         // when, then
         assertThatThrownBy(() -> pinService.deletePinOnSubject(subject.getId(), TOKEN))
             .isInstanceOf(AllcllException.class)
-            .hasMessageContaining(AllcllErrorCode.PIN_AND_SUBJECT_NOT_MATCH.getMessage());
+            .hasMessageContaining(AllcllErrorCode.PIN_SUBJECT_MISMATCH.getMessage());
     }
 
     private Subject createSubject(

--- a/src/test/java/kr/allcll/seatfinder/pin/PinServiceTest.java
+++ b/src/test/java/kr/allcll/seatfinder/pin/PinServiceTest.java
@@ -5,7 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.List;
 import kr.allcll.seatfinder.exception.AllcllException;
-import kr.allcll.seatfinder.exception.ExceptionMessage;
+import kr.allcll.seatfinder.exception.AllcllErrorCode;
 import kr.allcll.seatfinder.subject.Subject;
 import kr.allcll.seatfinder.subject.SubjectRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -77,7 +77,7 @@ class PinServiceTest {
         // when, then
         assertThatThrownBy(() -> pinService.addPinOnSubject(overCountSubject.getId(), TOKEN))
             .isInstanceOf(AllcllException.class)
-            .hasMessageContaining(String.format(ExceptionMessage.MAX_PIN_EXCEPTION.getMessage(), MAX_PIN_NUMBER));
+            .hasMessageContaining(String.format(AllcllErrorCode.MAX_PIN_EXCEPTION.getMessage(), MAX_PIN_NUMBER));
     }
 
 
@@ -92,7 +92,7 @@ class PinServiceTest {
         // when, then
         assertThatThrownBy(() -> pinService.addPinOnSubject(subject.getId(), TOKEN))
             .isInstanceOf(AllcllException.class)
-            .hasMessageContaining(ExceptionMessage.EXIST_PIN_EXCEPTION.getMessage());
+            .hasMessageContaining(AllcllErrorCode.EXIST_PIN_EXCEPTION.getMessage());
     }
 
     @Test
@@ -123,7 +123,7 @@ class PinServiceTest {
         // when, then
         assertThatThrownBy(() -> pinService.deletePinOnSubject(notPinnedSubject.getId(), token))
             .isInstanceOf(AllcllException.class)
-            .hasMessageContaining(ExceptionMessage.PIN_AND_SUBJECT_NOT_MATCH.getMessage());
+            .hasMessageContaining(AllcllErrorCode.PIN_AND_SUBJECT_NOT_MATCH.getMessage());
     }
 
     @Test
@@ -136,7 +136,7 @@ class PinServiceTest {
         // when, then
         assertThatThrownBy(() -> pinService.deletePinOnSubject(subject.getId(), TOKEN))
             .isInstanceOf(AllcllException.class)
-            .hasMessageContaining(ExceptionMessage.PIN_AND_SUBJECT_NOT_MATCH.getMessage());
+            .hasMessageContaining(AllcllErrorCode.PIN_AND_SUBJECT_NOT_MATCH.getMessage());
     }
 
     private Subject createSubject(

--- a/src/test/java/kr/allcll/seatfinder/pin/PinServiceTest.java
+++ b/src/test/java/kr/allcll/seatfinder/pin/PinServiceTest.java
@@ -4,6 +4,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.List;
+import kr.allcll.seatfinder.exception.AllcllException;
+import kr.allcll.seatfinder.exception.ExceptionMessage;
 import kr.allcll.seatfinder.subject.Subject;
 import kr.allcll.seatfinder.subject.SubjectRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -18,9 +20,6 @@ import org.springframework.transaction.annotation.Transactional;
 class PinServiceTest {
 
     private static final int MAX_PIN_NUMBER = 5;
-    private static final String PIN_REPOSITORY_FIND_ERROR_MESSAGE = "핀에 등록된 과목이 아닙니다.";
-    private static final String EXIST_PIN_ERROR_MESSAGE = "이미 핀 등록된 과목 입니다.";
-    private static final String OVER_PIN_COUNT_ERROR_MESSAGE = String.format("이미 %d개의 핀을 등록했습니다.", MAX_PIN_NUMBER);
 
     @Autowired
     private PinService pinService;
@@ -77,8 +76,8 @@ class PinServiceTest {
 
         // when, then
         assertThatThrownBy(() -> pinService.addPinOnSubject(overCountSubject.getId(), TOKEN))
-            .isInstanceOf(IllegalArgumentException.class)
-            .hasMessageContaining(OVER_PIN_COUNT_ERROR_MESSAGE);
+            .isInstanceOf(AllcllException.class)
+            .hasMessageContaining(String.format(ExceptionMessage.MAX_PIN_EXCEPTION.getMessage(), MAX_PIN_NUMBER));
     }
 
 
@@ -92,8 +91,8 @@ class PinServiceTest {
 
         // when, then
         assertThatThrownBy(() -> pinService.addPinOnSubject(subject.getId(), TOKEN))
-            .isInstanceOf(IllegalArgumentException.class)
-            .hasMessageContaining(EXIST_PIN_ERROR_MESSAGE);
+            .isInstanceOf(AllcllException.class)
+            .hasMessageContaining(ExceptionMessage.EXIST_PIN_EXCEPTION.getMessage());
     }
 
     @Test
@@ -123,8 +122,8 @@ class PinServiceTest {
 
         // when, then
         assertThatThrownBy(() -> pinService.deletePinOnSubject(notPinnedSubject.getId(), token))
-            .isInstanceOf(IllegalArgumentException.class)
-            .hasMessageContaining(PIN_REPOSITORY_FIND_ERROR_MESSAGE);
+            .isInstanceOf(AllcllException.class)
+            .hasMessageContaining(ExceptionMessage.PIN_AND_SUBJECT_NOT_MATCH.getMessage());
     }
 
     @Test
@@ -136,8 +135,8 @@ class PinServiceTest {
 
         // when, then
         assertThatThrownBy(() -> pinService.deletePinOnSubject(subject.getId(), TOKEN))
-            .isInstanceOf(IllegalArgumentException.class)
-            .hasMessageContaining(PIN_REPOSITORY_FIND_ERROR_MESSAGE);
+            .isInstanceOf(AllcllException.class)
+            .hasMessageContaining(ExceptionMessage.PIN_AND_SUBJECT_NOT_MATCH.getMessage());
     }
 
     private Subject createSubject(


### PR DESCRIPTION
## 작업 내용
- 공통 예외 코드를 작성하였습니다.
    - 어플리케이션 코드는 최대한 깔끔하게 하고싶어서, `AllcllException`클래스에 ~~정팩메를~~ constructor 넣었어요. enum만 받으면 알아서 code랑 message만들어주게....
- 제가 작업하였던 pin api에 적용하고, 테스트에서도 커스텀 예외를 사용하도록 하였습니다.
- 테스트에도 커스텀 예외를 가져다 쓰니까 좋아요. 저번 pr에서 걱정했던 포인트들이 많이 해결되는 것 같어용. 관리 포인트도 줄고 휴먼에러로 불필요한 리소스를 낭비하지 않을 수 있을 것 같아요. 무슨 느낌인지 아시져

## 고민 지점과 리뷰 포인트
- AllcllException 커스텀 예외 클래스에 
  ```java
    public static AllcllException of(int number, ExceptionMessage e) {
        String exceptionMessage = String.format(e.getMessage(), number);
        return new AllcllException(exceptionMessage, e.name());
    }
    ```
    요 부분이 있거든요? 이건 저희 핀 개수 제한이 있잖아요, 그 숫자 정보도 주려고 넣었는데요,,, 너무 저거 하나 때문에 만든 메서드인가 싶어서 다른 방법이 있을 지 고민하게 되어요! 재사용성이 너무 떨어질 것 같아서 좋은질 모르겠어요. `MAX_PIN_EXCEPTION("이미 %d개의 핀을 등록했습니다."),` 이 아이만을 위한 메서드이잖아요?..

이외에는 개선점이 어떤 것이 있을지 제시해주시면 감사하겠습니다🐥🐥

<!-- 예상되는 리팩터링 지점이 있다면 추가로 작성해 주세요.-->