### PR TITLE
feat: 핀 조회 기능 구현

### DIFF
--- a/src/main/java/kr/allcll/seatfinder/pin/PinApi.java
+++ b/src/main/java/kr/allcll/seatfinder/pin/PinApi.java
@@ -1,8 +1,7 @@
 package kr.allcll.seatfinder.pin;
 
-import java.util.List;
 import kr.allcll.seatfinder.ThreadLocalHolder;
-import kr.allcll.seatfinder.pin.dto.PinSubjectResponse;
+import kr.allcll.seatfinder.pin.dto.SubjectIdsResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -31,8 +30,8 @@ public class PinApi {
     }
 
     @GetMapping("/api/pins")
-    public ResponseEntity<List<PinSubjectResponse>> retrievePins() {
-        List<PinSubjectResponse> response = pinService.retrievePins(ThreadLocalHolder.SHARED_TOKEN.get());
+    public ResponseEntity<SubjectIdsResponse> retrievePins() {
+        SubjectIdsResponse response = pinService.retrievePins(ThreadLocalHolder.SHARED_TOKEN.get());
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/kr/allcll/seatfinder/pin/PinApi.java
+++ b/src/main/java/kr/allcll/seatfinder/pin/PinApi.java
@@ -1,9 +1,12 @@
 package kr.allcll.seatfinder.pin;
 
+import java.util.List;
 import kr.allcll.seatfinder.ThreadLocalHolder;
+import kr.allcll.seatfinder.pin.dto.PinSubjectResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -25,5 +28,11 @@ public class PinApi {
     public ResponseEntity<Void> deletePinOnSubject(@PathVariable Long subjectId) {
         pinService.deletePinOnSubject(subjectId, ThreadLocalHolder.SHARED_TOKEN.get());
         return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/api/pins")
+    public ResponseEntity<List<PinSubjectResponse>> retrievePins() {
+        List<PinSubjectResponse> response = pinService.retrievePins(ThreadLocalHolder.SHARED_TOKEN.get());
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/kr/allcll/seatfinder/pin/PinService.java
+++ b/src/main/java/kr/allcll/seatfinder/pin/PinService.java
@@ -3,6 +3,7 @@ package kr.allcll.seatfinder.pin;
 import java.util.List;
 import kr.allcll.seatfinder.exception.AllcllErrorCode;
 import kr.allcll.seatfinder.exception.AllcllException;
+import kr.allcll.seatfinder.pin.dto.PinSubjectResponse;
 import kr.allcll.seatfinder.subject.Subject;
 import kr.allcll.seatfinder.subject.SubjectRepository;
 import lombok.RequiredArgsConstructor;
@@ -44,5 +45,12 @@ public class PinService {
         Pin pin = pinRepository.findBySubjectAndToken(subject, token)
             .orElseThrow(() -> new AllcllException(AllcllErrorCode.PIN_SUBJECT_MISMATCH));
         pinRepository.deleteById(pin.getId());
+    }
+
+    public List<PinSubjectResponse> retrievePins(String token) {
+        List<Pin> pins = pinRepository.findAllByToken(token);
+        return pins.stream()
+            .map(pin -> new PinSubjectResponse(pin.getSubject().getId()))
+            .toList();
     }
 }

--- a/src/main/java/kr/allcll/seatfinder/pin/PinService.java
+++ b/src/main/java/kr/allcll/seatfinder/pin/PinService.java
@@ -3,7 +3,8 @@ package kr.allcll.seatfinder.pin;
 import java.util.List;
 import kr.allcll.seatfinder.exception.AllcllErrorCode;
 import kr.allcll.seatfinder.exception.AllcllException;
-import kr.allcll.seatfinder.pin.dto.PinSubjectResponse;
+import kr.allcll.seatfinder.pin.dto.SubjectIdResponse;
+import kr.allcll.seatfinder.pin.dto.SubjectIdsResponse;
 import kr.allcll.seatfinder.subject.Subject;
 import kr.allcll.seatfinder.subject.SubjectRepository;
 import lombok.RequiredArgsConstructor;
@@ -47,10 +48,10 @@ public class PinService {
         pinRepository.deleteById(pin.getId());
     }
 
-    public List<PinSubjectResponse> retrievePins(String token) {
+    public SubjectIdsResponse retrievePins(String token) {
         List<Pin> pins = pinRepository.findAllByToken(token);
-        return pins.stream()
-            .map(pin -> new PinSubjectResponse(pin.getSubject().getId()))
-            .toList();
+        return new SubjectIdsResponse(pins.stream()
+            .map(pin -> new SubjectIdResponse(pin.getSubject().getId()))
+            .toList());
     }
 }

--- a/src/main/java/kr/allcll/seatfinder/pin/dto/PinSubjectResponse.java
+++ b/src/main/java/kr/allcll/seatfinder/pin/dto/PinSubjectResponse.java
@@ -1,0 +1,7 @@
+package kr.allcll.seatfinder.pin.dto;
+
+public record PinSubjectResponse(
+    Long subjectId
+) {
+
+}

--- a/src/main/java/kr/allcll/seatfinder/pin/dto/SubjectIdResponse.java
+++ b/src/main/java/kr/allcll/seatfinder/pin/dto/SubjectIdResponse.java
@@ -1,6 +1,6 @@
 package kr.allcll.seatfinder.pin.dto;
 
-public record PinSubjectResponse(
+public record SubjectIdResponse(
     Long subjectId
 ) {
 

--- a/src/main/java/kr/allcll/seatfinder/pin/dto/SubjectIdsResponse.java
+++ b/src/main/java/kr/allcll/seatfinder/pin/dto/SubjectIdsResponse.java
@@ -3,7 +3,7 @@ package kr.allcll.seatfinder.pin.dto;
 import java.util.List;
 
 public record SubjectIdsResponse(
-    List<SubjectIdResponse> subjectIds
+    List<SubjectIdResponse> subjects
 ) {
 
 }

--- a/src/main/java/kr/allcll/seatfinder/pin/dto/SubjectIdsResponse.java
+++ b/src/main/java/kr/allcll/seatfinder/pin/dto/SubjectIdsResponse.java
@@ -1,0 +1,9 @@
+package kr.allcll.seatfinder.pin.dto;
+
+import java.util.List;
+
+public record SubjectIdsResponse(
+    List<SubjectIdResponse> subjectIds
+) {
+
+}

--- a/src/test/java/kr/allcll/seatfinder/pin/PinApiTest.java
+++ b/src/test/java/kr/allcll/seatfinder/pin/PinApiTest.java
@@ -1,16 +1,23 @@
 package kr.allcll.seatfinder.pin;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.cookie;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import jakarta.servlet.http.Cookie;
+import java.util.List;
+import kr.allcll.seatfinder.pin.dto.SubjectIdResponse;
+import kr.allcll.seatfinder.pin.dto.SubjectIdsResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
 
 @WebMvcTest(PinApi.class)
 class PinApiTest {
@@ -23,8 +30,8 @@ class PinApiTest {
 
     private static final String BASE_URL = "/api/pin";
 
-    @DisplayName("핀 등록을 할 때에 요청과 응답을 확인한다.")
     @Test
+    @DisplayName("핀 등록을 할 때에 요청과 응답을 확인한다.")
     void addPinOnSubjectWhenPinNotExist() throws Exception {
         // when, then
         mockMvc.perform(post(BASE_URL)
@@ -32,11 +39,31 @@ class PinApiTest {
             .andExpect(status().isOk());
     }
 
-    @DisplayName("핀을 삭제할 때 요청과 응답을 확인한다.")
     @Test
+    @DisplayName("핀을 삭제할 때 요청과 응답을 확인한다.")
     void deletePinOnSubject() throws Exception {
         // when, then
         mockMvc.perform(delete(BASE_URL + "/{subjectId}", 1L))
             .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("핀을 조회할 때 요청과 응답을 확인한다.")
+    void retrievePins() throws Exception {
+        // given
+        String expect = "{\"subjects\":[{\"subjectId\":1},{\"subjectId\":2}]}";
+
+        List<SubjectIdResponse> subjects = List.of(new SubjectIdResponse(1L), new SubjectIdResponse(2L));
+        when(pinService.retrievePins("tokenValue"))
+            .thenReturn(new SubjectIdsResponse(subjects));
+
+        // when
+        MvcResult result = mockMvc.perform(get("/api/pins")
+                .cookie(new Cookie("token", "tokenValue")))
+            .andExpect(status().isOk())
+            .andReturn();
+
+        // then
+        assertThat(result.getResponse().getContentAsString()).isEqualToIgnoringWhitespace(expect);
     }
 }

--- a/src/test/java/kr/allcll/seatfinder/pin/PinApiTest.java
+++ b/src/test/java/kr/allcll/seatfinder/pin/PinApiTest.java
@@ -51,7 +51,18 @@ class PinApiTest {
     @DisplayName("핀을 조회할 때 요청과 응답을 확인한다.")
     void retrievePins() throws Exception {
         // given
-        String expect = "{\"subjects\":[{\"subjectId\":1},{\"subjectId\":2}]}";
+        String expected = """
+                {
+                    "subjects":[
+                        {
+                            "subjectId":1
+                        },
+                        {
+                            "subjectId":2
+                        }
+                    ]
+                }
+            """;
 
         List<SubjectIdResponse> subjects = List.of(new SubjectIdResponse(1L), new SubjectIdResponse(2L));
         when(pinService.retrievePins("tokenValue"))
@@ -64,6 +75,6 @@ class PinApiTest {
             .andReturn();
 
         // then
-        assertThat(result.getResponse().getContentAsString()).isEqualToIgnoringWhitespace(expect);
+        assertThat(result.getResponse().getContentAsString()).isEqualToIgnoringWhitespace(expected);
     }
 }

--- a/src/test/java/kr/allcll/seatfinder/pin/PinServiceTest.java
+++ b/src/test/java/kr/allcll/seatfinder/pin/PinServiceTest.java
@@ -6,7 +6,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.util.List;
 import kr.allcll.seatfinder.exception.AllcllErrorCode;
 import kr.allcll.seatfinder.exception.AllcllException;
-import kr.allcll.seatfinder.pin.dto.PinSubjectResponse;
+import kr.allcll.seatfinder.pin.dto.SubjectIdsResponse;
 import kr.allcll.seatfinder.subject.Subject;
 import kr.allcll.seatfinder.subject.SubjectRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -150,10 +150,10 @@ class PinServiceTest {
         pinRepository.save(new Pin(TOKEN, subject));
 
         // when
-        List<PinSubjectResponse> responses = pinService.retrievePins(TOKEN);
+        SubjectIdsResponse response = pinService.retrievePins(TOKEN);
 
         // then
-        assertThat(responses).hasSize(expectSize);
+        assertThat(response.subjectIds()).hasSize(expectSize);
     }
 
     @DisplayName("등록된 핀이 존재할 때 예외가 발생하지 않음을 검증한다.")
@@ -163,10 +163,10 @@ class PinServiceTest {
         int expectSize = 0;
 
         // when
-        List<PinSubjectResponse> responses = pinService.retrievePins(TOKEN);
+        SubjectIdsResponse response = pinService.retrievePins(TOKEN);
 
         // then
-        assertThat(responses).hasSize(expectSize);
+        assertThat(response.subjectIds()).hasSize(expectSize);
     }
 
     private Subject createSubject(

--- a/src/test/java/kr/allcll/seatfinder/pin/PinServiceTest.java
+++ b/src/test/java/kr/allcll/seatfinder/pin/PinServiceTest.java
@@ -40,8 +40,8 @@ class PinServiceTest {
         subjectRepository.deleteAllInBatch();
     }
 
-    @DisplayName("핀이 5개 미만일 경우 정상 등록을 검증한다.")
     @Test
+    @DisplayName("핀이 5개 미만일 경우 정상 등록을 검증한다.")
     void addPinOnSubject() {
         // given
         Subject subjectA = createSubject("컴퓨터구조", "003278", "001", "김보예");
@@ -55,8 +55,8 @@ class PinServiceTest {
         assertThat(result).hasSize(1);
     }
 
-    @DisplayName("핀이 5개 이상일 경우 예외를 검증한다.")
     @Test
+    @DisplayName("핀이 5개 이상일 경우 예외를 검증한다.")
     void canNotAddPinOnSubject() {
         // given
         Subject subjectA = createSubject("컴퓨터구조", "003278", "001", "김보예");
@@ -82,8 +82,8 @@ class PinServiceTest {
     }
 
 
-    @DisplayName("이미 핀 등록된 과목일 경우 예외를 검증한다.")
     @Test
+    @DisplayName("이미 핀 등록된 과목일 경우 예외를 검증한다.")
     void alreadyExistPinSubject() {
         // given
         Subject subject = createSubject("컴퓨터구조", "003278", "001", "김보예");
@@ -97,8 +97,8 @@ class PinServiceTest {
             .hasMessageContaining(expectExceptionMessage);
     }
 
-    @DisplayName("핀의 삭제를 검증한다.")
     @Test
+    @DisplayName("핀의 삭제를 검증한다.")
     void deletePin() {
         // given
         Subject subject = createSubject("컴퓨터구조", "003278", "001", "김보예");
@@ -112,8 +112,8 @@ class PinServiceTest {
         assertThat(pinRepository.findAllByToken(TOKEN)).hasSize(0);
     }
 
-    @DisplayName("등록되지 않은 핀의 삭제에 대한 예외를 검증한다.")
     @Test
+    @DisplayName("등록되지 않은 핀의 삭제에 대한 예외를 검증한다.")
     void deleteNotExistPin() {
         // given
         Subject pinnedSubject = createSubject("핀과목", "123456", "001", "김보예");
@@ -127,8 +127,8 @@ class PinServiceTest {
             .hasMessageContaining(AllcllErrorCode.PIN_SUBJECT_MISMATCH.getMessage());
     }
 
-    @DisplayName("존재하지 않는 토큰에 대한 예외를 검증한다.")
     @Test
+    @DisplayName("존재하지 않는 토큰에 대한 예외를 검증한다.")
     void deleteNotExistToken() {
         // given
         Subject subject = createSubject("컴퓨터구조", "003278", "001", "김보예");
@@ -140,11 +140,11 @@ class PinServiceTest {
             .hasMessageContaining(AllcllErrorCode.PIN_SUBJECT_MISMATCH.getMessage());
     }
 
-    @DisplayName("등록된 핀이 존재할 때 조회 기능을 테스트한다.")
     @Test
+    @DisplayName("등록된 핀이 존재할 때 조회 기능을 테스트한다.")
     void retrieveExistPins() {
         // given
-        int expectSize = 1;
+        int expectedSize = 1;
         Subject subject = createSubject("컴퓨터구조", "003278", "001", "김보예");
         subjectRepository.save(subject);
         pinRepository.save(new Pin(TOKEN, subject));
@@ -153,20 +153,20 @@ class PinServiceTest {
         SubjectIdsResponse response = pinService.retrievePins(TOKEN);
 
         // then
-        assertThat(response.subjects()).hasSize(expectSize);
+        assertThat(response.subjects()).hasSize(expectedSize);
     }
 
-    @DisplayName("등록된 핀이 존재할 때 예외가 발생하지 않음을 검증한다.")
     @Test
+    @DisplayName("등록된 핀이 존재할 때 예외가 발생하지 않음을 검증한다.")
     void retrievePins() {
         // given
-        int expectSize = 0;
+        int expectedSize = 0;
 
         // when
         SubjectIdsResponse response = pinService.retrievePins(TOKEN);
 
         // then
-        assertThat(response.subjects()).hasSize(expectSize);
+        assertThat(response.subjects()).hasSize(expectedSize);
     }
 
     private Subject createSubject(

--- a/src/test/java/kr/allcll/seatfinder/pin/PinServiceTest.java
+++ b/src/test/java/kr/allcll/seatfinder/pin/PinServiceTest.java
@@ -153,7 +153,7 @@ class PinServiceTest {
         SubjectIdsResponse response = pinService.retrievePins(TOKEN);
 
         // then
-        assertThat(response.subjectIds()).hasSize(expectSize);
+        assertThat(response.subjects()).hasSize(expectSize);
     }
 
     @DisplayName("등록된 핀이 존재할 때 예외가 발생하지 않음을 검증한다.")
@@ -166,7 +166,7 @@ class PinServiceTest {
         SubjectIdsResponse response = pinService.retrievePins(TOKEN);
 
         // then
-        assertThat(response.subjectIds()).hasSize(expectSize);
+        assertThat(response.subjects()).hasSize(expectSize);
     }
 
     private Subject createSubject(


### PR DESCRIPTION
## 작업 내용
등록된 핀 조회하는 기능을 구현했습니다.
핀이 아무것도 없어두 예외처리는 하지 않았습니다. 예외가 아니라고 생각해서용. 추가적 로직도 구현하지는 않았어요. 그냥 빈 리스트를 반환해도 좋다고 생각해서용
그리고요 처음에 저희가 전체 과목에 대한 데이터를 전달해주고 시작하잖아요? 그래서 subjectId를 전해주는 것으로 명세를 수정했어요. 왜냐하면 그 과목에 대한 여석 정보도 항상 요청해야하잖아요. 그래서 id를 전해주는게 더 편리하겠다고 생각했습니다. 과목id로 바로 요청하면 되니까용.
쓰다보니 드는 생각이, 핀 등록한 여석 정보는 폴링 방식으로 해도 되겠다는 생각이 드네요?... 이건 합의 후 구현하기 나름일 것 같습니다.

## 고민 지점과 리뷰 포인트
제가 빼놓은 정책이 있는지 한 번 검토 같이 해 주시면 감사하겠습니다

<!-- 예상되는 리팩터링 지점이 있다면 추가로 작성해 주세요.-->