### PR TITLE
test: 전체 조회 기능 테스트 작성(검색 api를 활용할 수 있다.)

### DIFF
--- a/src/test/java/kr/allcll/seatfinder/subject/SubjectServiceTest.java
+++ b/src/test/java/kr/allcll/seatfinder/subject/SubjectServiceTest.java
@@ -44,8 +44,8 @@ class SubjectServiceTest {
         );
     }
 
-    @DisplayName("과목명으로 과목을 조회한다.")
     @Test
+    @DisplayName("과목명으로 과목을 조회한다.")
     void findSubjectByQueryTest() {
         SubjectsResponse subjectsResponse = subjectService.findSubjectsByCondition(null, "컴퓨터구조", null, null, null);
 
@@ -62,8 +62,8 @@ class SubjectServiceTest {
             );
     }
 
-    @DisplayName("학수번호, 분반, 교수명으로 과목을 조회한다.")
     @Test
+    @DisplayName("학수번호, 분반, 교수명으로 과목을 조회한다.")
     void findSubjectByQueryTest2() {
         SubjectsResponse subjectsResponse = subjectService.findSubjectsByCondition(null, null, "003279", "001", "노홍철");
 
@@ -79,12 +79,22 @@ class SubjectServiceTest {
             );
     }
 
-    @DisplayName("존재하지 않는 조건으로 과목을 조회한다.")
     @Test
+    @DisplayName("존재하지 않는 조건으로 과목을 조회한다.")
     void findSubjectByQueryTest3() {
         SubjectsResponse subjectsResponse = subjectService.findSubjectsByCondition(100L, null, "003279", "001",
             "유재석");
 
         assertThat(subjectsResponse.subjectResponses()).hasSize(0);
+    }
+
+    @Test
+    @DisplayName("전체 과목을 조회한다.")
+    void getAllSubjects() {
+        // when
+        SubjectsResponse allSubjects = subjectService.findSubjectsByCondition(null, null, null, null, null);
+
+        // then
+        assertThat(allSubjects.subjectResponses()).hasSize(8);
     }
 }


### PR DESCRIPTION
## 작업 내용
원래 전체 과목 조회를 처음에 선행해야 하니까 그 엔드포인트가 따로 있었잖아요?
근데 보니까 과목 검색 api에 아무 검색 정보도 안넣고 조회하면 전부 제공이 되게 되어있더라구요
그래서 그 기능 테스트만 추가했습니다.

## 고민 지점과 리뷰 포인트
그런데요, 저번에 주환님 리뷰를 받고 테스트 수정을 한 적이 있거든요? 그 때 받았던 피드백중에 테스트 메서드 딱 하나만 보고도 기능과 테스트하려는게 어떤 건지 알아야한다고 하셨었는데요,,
그런데 현재 Subject 관련 test들도 처음에 init되는 과목이 몇 개인지, 그런거를 파악하기가 너무 어려운 것 같아요.
주환님이 작성해 두신 테스트라 우선은 놔두었는데요, 혹시 다른 의도나 어쩔 수 없는 상황이 있었던 것 일까요?! 알려주세용

<!-- 예상되는 리팩터링 지점이 있다면 추가로 작성해 주세요.-->